### PR TITLE
0.5.0

### DIFF
--- a/Assets/KSP2UnityTools/KSP2UnityToolsSDK.uxml
+++ b/Assets/KSP2UnityTools/KSP2UnityToolsSDK.uxml
@@ -1,10 +1,10 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
     <ui:ScrollView>
         <ui:Label tabindex="-1" text="Mod Building" display-tooltip-when-elided="true" style="-unity-text-align: upper-center; -unity-font-style: bold;" />
-        <ui:DropdownField label="Build Mode" index="0" name="BuildMode" choices="Everything,Copy Addressables Only" />
+        <ui:DropdownField label="Build Mode" index="0" name="BuildMode" choices="Everything,Copy Assets Only" />
         <ui:VisualElement style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-direction: row;">
-            <ui:TextField picking-mode="Ignore" label="Build Path" name="BuildPath" tooltip="Should point to the folder you want to copy addressables into if set to copy addressables only, or the zip file you want to make" style="flex-grow: 1;" />
-            <ui:Button text="Browse" display-tooltip-when-elided="true" name="BrowseBuildPath" />
+            <ui:TextField picking-mode="Ignore" label="Build Path" name="BuildPath" tooltip="Should point to your mod folder if set to copy assets only, or the zip file you want to make" style="flex-grow: 1;" />
+            <ui:Button text="Browse" display-tooltip-when-elided="true" name="BrowseBuildPath" style="flex-shrink: 0; flex-grow: 0;" />
         </ui:VisualElement>
         <ui:Foldout text="Mod Info" name="ModInfoFoldout">
             <ui:TextField picking-mode="Ignore" label="Mod ID" value="sampleMod" name="ModID" />
@@ -34,7 +34,7 @@
         <ui:Label tabindex="-1" text="Mod Testing" display-tooltip-when-elided="true" style="-unity-text-align: upper-center; -unity-font-style: bold;" />
     </ui:ScrollView>
     <ui:VisualElement style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-direction: row;">
-        <ui:TextField picking-mode="Ignore" label="Mod Addressables" name="ModAddressablesFolder" tooltip="This points to the addressables folder of your mod in game" style="flex-grow: 1;" />
+        <ui:TextField picking-mode="Ignore" label="In Game Mod Folder" name="ModAddressablesFolder" tooltip="This points to the addressables folder of your mod in game" style="flex-grow: 1;" />
         <ui:Button text="Browse" display-tooltip-when-elided="true" name="BrowseAddressablesPath" />
     </ui:VisualElement>
     <ui:VisualElement style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-direction: row;">

--- a/Assets/KSP2UnityTools/KSP2UnityToolsSDK.uxml
+++ b/Assets/KSP2UnityTools/KSP2UnityToolsSDK.uxml
@@ -1,5 +1,6 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
     <ui:ScrollView>
+        <ui:Label tabindex="-1" text="Mod Building" display-tooltip-when-elided="true" style="-unity-text-align: upper-center; -unity-font-style: bold;" />
         <ui:DropdownField label="Build Mode" index="0" name="BuildMode" choices="Everything,Copy Addressables Only" />
         <ui:VisualElement style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-direction: row;">
             <ui:TextField picking-mode="Ignore" label="Build Path" name="BuildPath" tooltip="Should point to the folder you want to copy addressables into if set to copy addressables only, or the zip file you want to make" style="flex-grow: 1;" />
@@ -30,5 +31,15 @@
         <ui:Button text="Generate swinfo.json" display-tooltip-when-elided="true" name="GenerateSwinfo" />
         <ui:Button text="Import swinfo.json" display-tooltip-when-elided="true" name="ImportSwinfo" />
         <ui:Button text="Build Mod" display-tooltip-when-elided="true" name="BuildMod" tooltip="Generates into the aforementioned build path" />
+        <ui:Label tabindex="-1" text="Mod Testing" display-tooltip-when-elided="true" style="-unity-text-align: upper-center; -unity-font-style: bold;" />
     </ui:ScrollView>
+    <ui:VisualElement style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-direction: row;">
+        <ui:TextField picking-mode="Ignore" label="Mod Addressables" name="ModAddressablesFolder" tooltip="This points to the addressables folder of your mod in game" style="flex-grow: 1;" />
+        <ui:Button text="Browse" display-tooltip-when-elided="true" name="BrowseAddressablesPath" />
+    </ui:VisualElement>
+    <ui:VisualElement style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-direction: row;">
+        <ui:TextField picking-mode="Ignore" label="Game Path" name="GamePath" tooltip="Points to KSP2_x64.exe" style="flex-grow: 1;" />
+        <ui:Button text="Browse" display-tooltip-when-elided="true" name="BrowseGamePath" />
+    </ui:VisualElement>
+    <ui:Button text="Build And Test" display-tooltip-when-elided="true" name="BuildAndLaunch" />
 </ui:UXML>

--- a/Editor/FixUnity.cs
+++ b/Editor/FixUnity.cs
@@ -4,20 +4,20 @@ using UnityEngine;
 
 namespace Editor.KSP2UnityTools.Editor
 {
-    [InitializeOnLoad]
+    // [InitializeOnLoad]
     public static class FixUnity
     {
-        static FixUnity()
-        {
-            if (!SessionState.GetBool("FixedUnity", false))
-            {
-                Debug.Log("First init.");
-
-                SessionState.SetBool("FixedUnity", true);
-                
-                CreateDeleteScript();
-            }
-        }
+        // static FixUnity()
+        // {
+        //     if (!SessionState.GetBool("FixedUnity", false))
+        //     {
+        //         Debug.Log("First init.");
+        //
+        //         SessionState.SetBool("FixedUnity", true);
+        //         
+        //         CreateDeleteScript();
+        //     }
+        // }
         
         private static string _emptyMonobehaviour = @"
 using System.Collections;

--- a/Editor/FixUnity.cs
+++ b/Editor/FixUnity.cs
@@ -1,10 +1,24 @@
 using System.IO;
 using UnityEditor;
+using UnityEngine;
 
 namespace Editor.KSP2UnityTools.Editor
 {
+    [InitializeOnLoad]
     public static class FixUnity
     {
+        static FixUnity()
+        {
+            if (!SessionState.GetBool("FixedUnity", false))
+            {
+                Debug.Log("First init.");
+
+                SessionState.SetBool("FixedUnity", true);
+                
+                CreateDeleteScript();
+            }
+        }
+        
         private static string _emptyMonobehaviour = @"
 using System.Collections;
 using System.Collections.Generic;

--- a/Editor/KSP2UnityToolsSettings.cs
+++ b/Editor/KSP2UnityToolsSettings.cs
@@ -9,6 +9,8 @@ namespace KSP2UT.KSP2UnityTools
         public List<string> gameObjectValues = new();
         public string savedBuildPath = "";
         public string savedBuildMode = "Everything";
+        public string savedModAddressablesPath = "";
+        public string savedKsp2Path = "";
 
         public bool Contains(string key)
         {

--- a/Editor/KSP2UnityToolsWindow.cs
+++ b/Editor/KSP2UnityToolsWindow.cs
@@ -503,28 +503,28 @@ namespace Editor.Editor
             {
                 Directory.Delete($"{modPath}/addressables",true);
             }
-            CopyDirectory("Library/com.unity.addressables/aa/Windows", _modAddressablesPath.text, true);
+            CopyDirectory("Library/com.unity.addressables/aa/Windows", $"{modPath}/addressables", true);
             if (Directory.Exists("Assets/localizations"))
             {
-                CopyDirectory("Assets/localizations",$"{modPath}/{_projectModInfo.id}/localizations",true);
+                CopyDirectory("Assets/localizations",$"{modPath}/localizations",true);
             }
 
             if (Directory.Exists("Assets/assets"))
             {
                 CopyDirectory("Assets/assets",
-                    $"{modPath}/{_projectModInfo.id}/assets", true);
+                    $"{modPath}/assets", true);
             }
 
             if (Directory.Exists("Assets/patches"))
             {
                 CopyDirectory("Assets/patches",
-                    $"{modPath}/{_projectModInfo.id}/patches", true);
+                    $"{modPath}/patches", true);
             }
 
             if (Directory.Exists("Assets/libraries"))
             {
                 CopyDirectory("Assets/libraries",
-                    $"{modPath}/{_projectModInfo.id}/libraries", true);
+                    $"{modPath}/libraries", true);
             }
 
             if (BuildEverything)

--- a/Editor/KSP2UnityToolsWindow.cs
+++ b/Editor/KSP2UnityToolsWindow.cs
@@ -143,6 +143,7 @@ namespace Editor.Editor
             _buildMod.clicked += BuildAddressables;
 
             _modAddressablesPath = doc.Q<TextField>("ModAddressablesFolder");
+            _modAddressablesPath.value = KSP2UnityToolsManager.Settings.savedModAddressablesPath;
             _modAddressablesPath.RegisterValueChangedCallback(evt =>
             {
                 KSP2UnityToolsManager.Settings.savedModAddressablesPath = evt.newValue;
@@ -161,6 +162,7 @@ namespace Editor.Editor
                     EditorUtility.SaveFolderPanel("Mod Addressables Folder", "path", "addressables");
             };
             _gamePath = doc.Q<TextField>("GamePath");
+            _gamePath.value = KSP2UnityToolsManager.Settings.savedKsp2Path;
             _gamePath.RegisterValueChangedCallback(evt =>
             {
                 KSP2UnityToolsManager.Settings.savedKsp2Path = evt.newValue;
@@ -499,7 +501,7 @@ namespace Editor.Editor
             var modPath = _modAddressablesPath.value;
             if (Directory.Exists($"{modPath}/addressables"))
             {
-                Directory.Delete(_buildPath.text,true);
+                Directory.Delete($"{modPath}/addressables",true);
             }
             CopyDirectory("Library/com.unity.addressables/aa/Windows", _modAddressablesPath.text, true);
             if (Directory.Exists("Assets/localizations"))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "ksp2community.ksp2unitytools",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "displayName": "KSP 2 Unity Tools",
   "description": "A collection of Unity editor scripts and utilities to make developing Kerbal Space Program 2 mods easier.",
   "unity": "2022.3",


### PR DESCRIPTION
Adds more features to the SDK, changes copy addressables only, to copy assets only, builds asset bundles automatically as well into an `assets/bundles` folder in the project, copies over the following special folders now `assets`, `localizations`, `patches`, `libraries`, the latter 2 being for patch manager. Adds 2 new input fields and a button for building and testing mods in game straight from the unity editor.